### PR TITLE
- B Fixed script path issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.6
+
+- Updated dependencies. Removed `dcli` package.
+- Issue https://github.com/approvals/ApprovalTests.Dart/issues/3 was fixed.
+- Minor changes: `IDEComparator` now gets the current `StackTrace` if an error occurs.
+
 ## 0.4.5
 
 - Updated dependencies and actions versions.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  approval_tests: ^0.4.5
+  approval_tests: ^0.4.6
 ```
 
 ## 👀 Getting Started

--- a/lib/approval_tests.dart
+++ b/lib/approval_tests.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:mirrors';
 
-import 'package:dcli/dcli.dart';
 import 'package:talker/talker.dart';
 
 part 'src/approvals.dart';

--- a/lib/src/comparator/ide_comparator.dart
+++ b/lib/src/comparator/ide_comparator.dart
@@ -49,7 +49,7 @@ final class IDEComparator extends Comparator {
     throw IDEComparatorException(
       message: message,
       exception: null,
-      stackTrace: null,
+      stackTrace: StackTrace.current,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 #  * 0.0.4 for a minor release.
 name: approval_tests
 description: Approval Tests implementation in Dart. Inspired by ApprovalTests.
-version: 0.4.5
+version: 0.4.6
 repository: https://github.com/approvals/ApprovalTests.Dart
 homepage: https://github.com/approvals/ApprovalTests.Dart.git
 issue_tracker: https://github.com/approvals/ApprovalTests.Dart/issues
@@ -16,13 +16,11 @@ topics:
   - approval-tests
 
 environment:
-  sdk: ^3.3.4
+    sdk: '>=3.0.0 <4.0.0'
 
-# Add regular dependencies here.
 dependencies:
   test: ^1.25.5
   talker: ^4.2.0
-  dcli: ^3.4.0
 
 dev_dependencies:
   sizzle_lints: ^2.0.2

--- a/test/example/example_test.dart
+++ b/test/example/example_test.dart
@@ -9,6 +9,7 @@ void main() {
       'features': ['Testing', 'JSON'],
       'version': 0.1,
     };
+
     Approvals.verifyAsJson(
       complexObject,
       options: const Options(


### PR DESCRIPTION
- Updated dependencies. Removed `dcli` package.
- Issue https://github.com/approvals/ApprovalTests.Dart/issues/3 was fixed.
- Minor changes: `IDEComparator` now gets the current `StackTrace` if an error occurs.

