### PR TITLE
Feat/minor upds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.5
+## 1.3.6
 ### Improvements
 - Normalized JSON conversion to produce valid output for any map keys and optional class wrappers.
 - Preserved whitespace during comparisons by updating `ApprovalUtils.readFile` and `FileComparator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.1
+## 1.3.2
 ### Improvements
 - Normalized JSON conversion to produce valid output for any map keys and optional class wrappers.
 - Preserved whitespace during comparisons by updating `ApprovalUtils.readFile` and `FileComparator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.2
+## 1.3.3
 ### Improvements
 - Normalized JSON conversion to produce valid output for any map keys and optional class wrappers.
 - Preserved whitespace during comparisons by updating `ApprovalUtils.readFile` and `FileComparator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.3
+## 1.3.5
 ### Improvements
 - Normalized JSON conversion to produce valid output for any map keys and optional class wrappers.
 - Preserved whitespace during comparisons by updating `ApprovalUtils.readFile` and `FileComparator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 1.3.0
-### Quality Improvements
+## 1.3.1
+### Improvements
 - Normalized JSON conversion to produce valid output for any map keys and optional class wrappers.
 - Preserved whitespace during comparisons by updating `ApprovalUtils.readFile` and `FileComparator`.
 - Ensured received files delete even when result logging is disabled.

--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        https://www.apache.org/licenses/
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+1. Definitions.
 
-   1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+(a) You must give any other recipients of the Work or Derivative Works
+a copy of this License; and
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
 
-   END OF TERMS AND CONDITIONS
+APPENDIX: How to apply the Apache License to your work.
 
-   APPENDIX: How to apply the Apache License to your work.
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!) The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+Copyright 2024 Yelaman Yelmuratov
 
-   Copyright 2024 shodev.live
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
 
-       https://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  approval_tests: ^1.3.1
+  approval_tests: ^1.3.2
 ```
 
 ## 👀 Getting Started

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  approval_tests: ^1.3.2
+  approval_tests: ^1.3.3
 ```
 
 ## 👀 Getting Started

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  approval_tests: ^1.3.3
+  approval_tests: ^1.3.5
 ```
 
 ## 👀 Getting Started

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  approval_tests: ^1.3.0
+  approval_tests: ^1.3.1
 ```
 
 ## 👀 Getting Started

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the following to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  approval_tests: ^1.3.5
+  approval_tests: ^1.3.6
 ```
 
 ## 👀 Getting Started

--- a/lib/src/core/logger/logger.dart
+++ b/lib/src/core/logger/logger.dart
@@ -28,13 +28,13 @@ final class ApprovalLogger {
       settings: TalkerSettings(
         titles: _defaultTitles,
         colors: {
-          TalkerLogType.critical.key: AnsiPen()..red(),
-          TalkerLogType.warning.key: AnsiPen()..yellow(),
-          TalkerLogType.verbose.key: AnsiPen()..gray(),
-          TalkerLogType.info.key: AnsiPen()..cyan(),
-          TalkerLogType.debug.key: AnsiPen()..gray(),
-          TalkerLogType.error.key: ApprovalUtils.hexToAnsiPen('de7979'),
-          TalkerLogType.exception.key: ApprovalUtils.hexToAnsiPen('de7979'),
+          'critical': AnsiPen()..red(),
+          'warning': AnsiPen()..yellow(),
+          'verbose': AnsiPen()..gray(),
+          'info': AnsiPen()..cyan(),
+          'debug': AnsiPen()..gray(),
+          'error': ApprovalUtils.hexToAnsiPen('de7979'),
+          'exception': ApprovalUtils.hexToAnsiPen('de7979'),
         },
       ),
     ),
@@ -48,13 +48,13 @@ final class ApprovalLogger {
 
   // Define default titles for different log types.
   static Map<String, String> _defaultTitles = {
-    TalkerLogType.critical.key: '💀 $_approvalTitle',
-    TalkerLogType.warning.key: '🟡 $_approvalTitle',
-    TalkerLogType.verbose.key: '🐛 $_approvalTitle',
-    TalkerLogType.info.key: '🔍 $_approvalTitle',
-    TalkerLogType.debug.key: '🐛 $_approvalTitle',
-    TalkerLogType.error.key: '🔴 $_approvalTitle',
-    TalkerLogType.exception.key: '🔴 $_approvalTitle',
+    'critical': '💀 $_approvalTitle',
+    'warning': '🟡 $_approvalTitle',
+    'verbose': '🐛 $_approvalTitle',
+    'info': '🔍 $_approvalTitle',
+    'debug': '🐛 $_approvalTitle',
+    'error': '🔴 $_approvalTitle',
+    'exception': '🔴 $_approvalTitle',
   };
 
   /// `log` method to log messages with debug log level.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 #  * 0.0.4 for a minor release.
 name: approval_tests
 description: Approval Tests implementation in Dart. Inspired by ApprovalTests.
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/approvals/ApprovalTests.Dart
 homepage: https://github.com/approvals/ApprovalTests.Dart.git
 issue_tracker: https://github.com/approvals/ApprovalTests.Dart/issues
@@ -19,11 +19,11 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  meta: ^1.17.0
-  test: ^1.25.2
-  talker: ^4.6.11
+  meta: ^1.16.0
+  test: ^1.26.3
+  talker: ^5.0.2
   diff_match_patch2: ^0.5.0
-  test_api: ^0.7.3
+  test_api: ^0.7.7
 
 dev_dependencies:
-  sizzle_lints: ^2.1.4
+  sizzle_lints: ^2.1.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 #  * 0.0.4 for a minor release.
 name: approval_tests
 description: Approval Tests implementation in Dart. Inspired by ApprovalTests.
-version: 1.3.3
+version: 1.3.5
 repository: https://github.com/approvals/ApprovalTests.Dart
 homepage: https://github.com/approvals/ApprovalTests.Dart.git
 issue_tracker: https://github.com/approvals/ApprovalTests.Dart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 #  * 0.0.4 for a minor release.
 name: approval_tests
 description: Approval Tests implementation in Dart. Inspired by ApprovalTests.
-version: 1.3.1
+version: 1.3.2
 repository: https://github.com/approvals/ApprovalTests.Dart
 homepage: https://github.com/approvals/ApprovalTests.Dart.git
 issue_tracker: https://github.com/approvals/ApprovalTests.Dart/issues
@@ -23,7 +23,7 @@ dependencies:
   test: ^1.26.3
   talker: ^5.0.2
   diff_match_patch2: ^0.5.0
-  test_api: ^0.7.7
+  test_api: ^0.7.4
 
 dev_dependencies:
   sizzle_lints: ^2.1.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 #  * 0.0.4 for a minor release.
 name: approval_tests
 description: Approval Tests implementation in Dart. Inspired by ApprovalTests.
-version: 1.3.5
+version: 1.3.6
 repository: https://github.com/approvals/ApprovalTests.Dart
 homepage: https://github.com/approvals/ApprovalTests.Dart.git
 issue_tracker: https://github.com/approvals/ApprovalTests.Dart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 #  * 0.0.4 for a minor release.
 name: approval_tests
 description: Approval Tests implementation in Dart. Inspired by ApprovalTests.
-version: 1.3.2
+version: 1.3.3
 repository: https://github.com/approvals/ApprovalTests.Dart
 homepage: https://github.com/approvals/ApprovalTests.Dart.git
 issue_tracker: https://github.com/approvals/ApprovalTests.Dart/issues
@@ -20,7 +20,7 @@ environment:
 
 dependencies:
   meta: ^1.16.0
-  test: ^1.26.3
+  test: ^1.25.0
   talker: ^5.0.2
   diff_match_patch2: ^0.5.0
   test_api: ^0.7.4


### PR DESCRIPTION
This pull request updates the package to version 1.3.6 and includes several improvements, dependency updates, and license corrections. The most important changes are grouped below:

**Release and Documentation Updates:**

* Bumped package version to `1.3.6` in `pubspec.yaml`, `README.md`, and updated the changelog with the latest improvements. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L6-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R61) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R2)

**Dependency Updates:**

* Updated dependencies in `pubspec.yaml`, including downgrading `meta` and `test` versions, upgrading `talker`, `test_api`, and `sizzle_lints` to newer versions for better compatibility and stability.

**Codebase Improvements:**

* Refactored `ApprovalLogger` in `logger.dart` to use string keys instead of `TalkerLogType.key` for log type mappings, improving maintainability and clarity. [[1]](diffhunk://#diff-acebe2cae7a6f453b38db042c4227ec0d32671871ec15a4058ef20b9d42a3c42L31-R37) [[2]](diffhunk://#diff-acebe2cae7a6f453b38db042c4227ec0d32671871ec15a4058ef20b9d42a3c42L51-R57)

**License and Legal Corrections:**

* Updated `LICENSE` to correct the copyright holder, fix URLs to use `http`, and improve formatting for compliance. [[1]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L1-R3) [[2]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L95-R95) [[3]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L190-R195)

These changes collectively improve the package's reliability, maintainability, and legal compliance.

## Summary by Sourcery

Upgrade package to version 1.3.6 with updated dependencies, a logging refactor, and license corrections

Enhancements:
- Update meta, test, talker, test_api, and sizzle_lints dependencies for improved compatibility
- Refactor ApprovalLogger to use string keys for log level mappings instead of TalkerLogType keys

Documentation:
- Bump version to 1.3.6 in pubspec.yaml, README, and CHANGELOG

Chores:
- Correct copyright holder, URLs, and formatting in LICENSE