### PR TITLE
Feat/minor upds

### DIFF
--- a/test/groups/reporter_arguments_test.dart
+++ b/test/groups/reporter_arguments_test.dart
@@ -139,8 +139,7 @@ void registerReporterArgumentsTests() {
 
     test('throws ProcessException when custom command exits non-zero',
         () async {
-      final tempDir =
-          Directory.systemTemp.createTempSync('diff_reporter_fail');
+      final tempDir = Directory.systemTemp.createTempSync('diff_reporter_fail');
       addTearDown(() => tempDir.deleteSync(recursive: true));
 
       final approved = File('${tempDir.path}/approved.txt')

--- a/test/groups/reporter_arguments_test.dart
+++ b/test/groups/reporter_arguments_test.dart
@@ -136,6 +136,37 @@ void registerReporterArgumentsTests() {
 
       expect(reporter.isReporterAvailable, isTrue);
     });
+
+    test('throws ProcessException when custom command exits non-zero',
+        () async {
+      final tempDir =
+          Directory.systemTemp.createTempSync('diff_reporter_fail');
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+
+      final approved = File('${tempDir.path}/approved.txt')
+        ..writeAsStringSync('approved');
+      final received = File('${tempDir.path}/received.txt')
+        ..writeAsStringSync('received');
+
+      final failingScript = _writeExitScript(
+        directory: tempDir,
+        fileName: 'diff_exit.dart',
+        exitCode: 3,
+      );
+
+      final reporter = DiffReporter(
+        customDiffInfo: DiffInfo(
+          name: 'fail',
+          command: Platform.resolvedExecutable,
+          arg: failingScript,
+        ),
+      );
+
+      await expectLater(
+        reporter.report(approved.path, received.path),
+        throwsA(isA<ProcessException>()),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
This pull request adds a new test to improve error handling coverage for custom diff reporter commands. The main change ensures that the `DiffReporter` correctly throws a `ProcessException` when a custom command exits with a non-zero code.

Error handling improvements:

* Added a test in `reporter_arguments_test.dart` to verify that `DiffReporter` throws a `ProcessException` when a custom diff command exits with a non-zero code, increasing robustness of error handling.

## Summary by Sourcery

Tests:
- Add test to verify DiffReporter throws a ProcessException when a custom diff command exits with a non-zero code